### PR TITLE
Optimized flow node execution by only trying to execute flow nodes that have incoming tokens

### DIFF
--- a/core/src/bpmn/process.rs
+++ b/core/src/bpmn/process.rs
@@ -1,9 +1,11 @@
 use crate::bpmn::flow_node::{FlowNode, SequenceFlow};
+use std::collections::HashMap;
 
 #[derive(Debug, PartialEq)]
 pub struct Process {
     pub id: String,
     pub flow_nodes: Vec<FlowNode>,
+    pub sequence_flow_index: HashMap<String, usize>, // Map from sf_id to target flow node index.
 }
 
 impl Process {
@@ -16,6 +18,8 @@ impl Process {
         let target_idx = self.find_flow_node_idx_by_id(target_ref);
         match (source_idx, target_idx) {
             (Some(source_idx), Some(target_idx)) => {
+                self.sequence_flow_index.insert(id.clone(), target_idx);
+
                 let source = self.flow_nodes.get_mut(source_idx).unwrap();
                 source.add_outgoing_flow(SequenceFlow {
                     id: id.clone(),

--- a/core/src/bpmn/reader_test.rs
+++ b/core/src/bpmn/reader_test.rs
@@ -5,6 +5,7 @@ mod tests {
     use crate::bpmn::flow_node::{EventType, FlowNode, TaskType};
     use crate::bpmn::process::Process;
     use crate::bpmn::reader::read_bpmn_from_file;
+    use std::collections::HashMap;
 
     const PATH: &str = "tests/resources/unit/";
 
@@ -36,7 +37,8 @@ mod tests {
         };
         let mut process = Process {
             id: String::from("process_id"),
-            flow_nodes: Vec::new(),
+            flow_nodes: vec![],
+            sequence_flow_index: HashMap::new(),
         };
         process.add_flow_node(FlowNode::new(
             String::from("start"),


### PR DESCRIPTION
This has a massive impact on benchmark models with many flow nodes like 400.bpmn and 500.bpmn. We went from 160ms to 2ms locally.